### PR TITLE
Fix high- and critical-severity production Dependabot alerts

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,13 +6,56 @@ import org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
+buildscript {
+    repositories {
+        mavenCentral()
+
+        val githubToken = System.getenv("GITHUB_TOKEN")
+        if (githubToken.isNullOrEmpty()) {
+            maven {
+                name = "external-mirror-github-navikt"
+                url = uri("https://github-package-registry-mirror.gc.nav.no/cached/maven-release")
+            }
+        } else {
+            maven {
+                name = "github-package-registry-navikt"
+                url = uri("https://maven.pkg.github.com/navikt/maven-release")
+                credentials {
+                    username = "token"
+                    password = githubToken
+                }
+            }
+        }
+        maven { url = uri("https://build.shibboleth.net/maven/releases/") }
+    }
+
+    configurations.classpath {
+        resolutionStrategy {
+            eachDependency {
+                if (requested.group == "org.codehaus.plexus" && requested.name == "plexus-utils") {
+                    useVersion("4.0.3")
+                    because(
+                        "Plexus-Utils has a Directory Traversal vulnerability in its extractFile method. " +
+                            "Affected version >= 4.0.0, < 4.0.3",
+                    )
+                }
+            }
+        }
+    }
+
+    dependencies {
+        classpath("com.gradleup.shadow:shadow-gradle-plugin:9.4.1")
+    }
+}
+
 plugins {
     kotlin("jvm") version "2.3.20"
     kotlin("plugin.serialization") version "2.3.20"
-    id("com.gradleup.shadow") version "9.4.1"
     id("org.jlleitschuh.gradle.ktlint") version "14.2.0"
     id("org.jetbrains.kotlinx.kover") version "0.9.8"
 }
+
+apply(plugin = "com.gradleup.shadow")
 
 group = "no.nav.sokos"
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,28 +7,6 @@ import org.gradle.api.tasks.testing.logging.TestLogEvent
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 buildscript {
-    repositories {
-        mavenCentral()
-
-        val githubToken = System.getenv("GITHUB_TOKEN")
-        if (githubToken.isNullOrEmpty()) {
-            maven {
-                name = "external-mirror-github-navikt"
-                url = uri("https://github-package-registry-mirror.gc.nav.no/cached/maven-release")
-            }
-        } else {
-            maven {
-                name = "github-package-registry-navikt"
-                url = uri("https://maven.pkg.github.com/navikt/maven-release")
-                credentials {
-                    username = "token"
-                    password = githubToken
-                }
-            }
-        }
-        maven { url = uri("https://build.shibboleth.net/maven/releases/") }
-    }
-
     configurations.classpath {
         resolutionStrategy {
             eachDependency {
@@ -42,20 +20,15 @@ buildscript {
             }
         }
     }
-
-    dependencies {
-        classpath("com.gradleup.shadow:shadow-gradle-plugin:9.4.1")
-    }
 }
 
 plugins {
     kotlin("jvm") version "2.3.20"
     kotlin("plugin.serialization") version "2.3.20"
+    id("com.gradleup.shadow") version "9.4.1"
     id("org.jlleitschuh.gradle.ktlint") version "14.2.0"
     id("org.jetbrains.kotlinx.kover") version "0.9.8"
 }
-
-apply(plugin = "com.gradleup.shadow")
 
 group = "no.nav.sokos"
 


### PR DESCRIPTION
# Scope

- Mode: default
- Eligible severity: high and critical only
- Only production/runtime dependencies were eligible
- Test-only and development-only dependencies were excluded
- All fixes are consolidated into one pull request
- Vulnerability and patched-version data came only from Dependabot alerts

# Summary

- Open alerts retrieved: 9
- Eligible under active mode: 1
- Fixed: 1
- Eligible but unresolved: 0
- Excluded by severity: 8
- Excluded because development/test-only: 0
- Changed manifest/module: `build.gradle.kts`

# Fixed alerts

| Alert | Advisory | Severity | Package | Previous version | New version | Dependency type | Production configuration | Remediation |
| ----- | -------- | -------- | ------- | ---------------- | ----------- | --------------- | ------------------------ | ----------- |
| 42 | GHSA-6fmv-xxpf-w3cw | high | org.codehaus.plexus:plexus-utils | 4.0.2 | 4.0.3 | plugin dependency | buildEnvironment / classpath | resolution strategy only |

# Eligible unresolved alerts

None.

# Excluded alerts

| Alert | Advisory | Severity | Scope | Exclusion reason |
| ----- | -------- | -------- | ----- | ---------------- |
| 61 | GHSA-rcgg-9c38-7xpx | medium | n/a | Severity outside active mode |
| 45 | GHSA-445c-vh5m-36rj | medium | n/a | Severity outside active mode |
| 44 | GHSA-6hg6-v5c8-fphq | medium | n/a | Severity outside active mode |
| 43 | GHSA-3pxv-7cmr-fjr4 | medium | n/a | Severity outside active mode |
| 34 | GHSA-qqpg-mvqg-649v | low | n/a | Severity outside active mode |
| 31 | GHSA-25qh-j22f-pwp8 | medium | n/a | Severity outside active mode |
| 30 | GHSA-6v67-2wr5-gvf4 | low | n/a | Severity outside active mode |
| 29 | GHSA-pr98-23f8-jwxv | medium | n/a | Severity outside active mode |

# Dependency verification

- `./gradlew dependencies --configuration runtimeClasspath`
- `./gradlew dependencyInsight --dependency tools.jackson.core:jackson-core --configuration runtimeClasspath`
- `./gradlew dependencyInsight --dependency com.fasterxml.jackson.core:jackson-core --configuration runtimeClasspath`
- `./gradlew dependencyInsight --dependency io.netty:netty-codec-http --configuration runtimeClasspath`
- `./gradlew dependencyInsight --dependency io.netty:netty-codec-http2 --configuration runtimeClasspath`
- `./gradlew dependencyInsight --dependency io.netty:netty-transport-native-epoll --configuration runtimeClasspath`
- `./gradlew dependencyInsight --dependency org.apache.neethi:neethi --configuration runtimeClasspath`
- `./gradlew dependencyInsight --dependency org.apache.commons:commons-lang3 --configuration runtimeClasspath`
- `./gradlew dependencyInsight --dependency org.bouncycastle:bcprov-jdk18on --configuration runtimeClasspath`
- `./gradlew dependencyInsight --dependency org.bouncycastle:bcpkix-jdk18on --configuration runtimeClasspath`
- `./gradlew buildEnvironment`

# Validation

- `./gradlew test` - passed
- `./gradlew build` - failed when run in parallel with another Gradle process, then passed when rerun sequentially
- `./gradlew buildEnvironment` - passed
